### PR TITLE
Show Stre domain link below search bar

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -7,9 +7,9 @@ export class App extends Component {
 
   componentDidMount() {
     fetch('https://strewebapp.riccardohs.it/api/get-stre-domain')
-      .then((res) => res.text())
+      .then((res) => res.json())
       .then((streDomain) => this.setState({ streDomain }))
-      .catch(() => {});
+      .catch(() => { });
   }
 
   render() {
@@ -27,7 +27,7 @@ export class App extends Component {
           </TouchableOpacity>
         </View>
         {this.state.streDomain && (
-          <TouchableOpacity onPress={() => Linking.openURL(this.state.streDomain)}>
+          <TouchableOpacity onPress={() => { Linking.openURL(`https://${this.state.streDomain}`)}}>
             <Text style={styles.link}>{this.state.streDomain}</Text>
           </TouchableOpacity>
         )}
@@ -81,3 +81,4 @@ const styles = StyleSheet.create({
     textDecorationLine: 'underline',
   },
 });
+


### PR DESCRIPTION
## Summary
- fetch domain from strewebapp API and show link under search bar

## Testing
- `npm run lint`
- `curl -v https://strewebapp.riccardohs.it/api/get-stre-domain` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689c52cd8e608333b372b46480102b44