### PR TITLE
feat: add details page for search results

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,6 +22,7 @@ export default function RootLayout() {
       <Stack>
         <Stack.Screen name="index" options={{ headerShown: false }} />
         <Stack.Screen name="results" options={{ title: 'Risultati' }} />
+        <Stack.Screen name="details/[completeSlug]" options={{ title: 'Dettagli' }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/app/details/[completeSlug].jsx
+++ b/app/details/[completeSlug].jsx
@@ -26,10 +26,15 @@ export default function Details() {
   const poster = Array.isArray(info.images)
     ? info.images.find((img) => img.type === 'cover')
     : null;
+  const background = Array.isArray(info.images)
+    ? info.images.find((img) => img.type === 'background')
+    : null;
   const posterUri = poster && domain ? `https://cdn.${domain}/images/${poster.filename}` : null;
+  const backgroundUri = background && domain ? `https://cdn.${domain}/images/${background.filename}` : null;
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      {backgroundUri && <Image source={{ uri: backgroundUri }} style={styles.background} />}
       {posterUri && <Image source={{ uri: posterUri }} style={styles.poster} />}
       <Text style={styles.title}>{info.name}</Text>
       {info.plot && <Text style={styles.plot}>{info.plot}</Text>}
@@ -51,6 +56,12 @@ const styles = StyleSheet.create({
     color: 'white',
     marginTop: 20,
     textAlign: 'center',
+  },
+  background: {
+    width: '100%',
+    height: 200,
+    borderRadius: 8,
+    marginBottom: 16,
   },
   poster: {
     width: '100%',

--- a/app/details/[completeSlug].jsx
+++ b/app/details/[completeSlug].jsx
@@ -23,19 +23,16 @@ export default function Details() {
     );
   }
 
-  const poster = Array.isArray(info.images)
-    ? info.images.find((img) => img.type === 'cover')
-    : null;
   const background = Array.isArray(info.images)
     ? info.images.find((img) => img.type === 'background')
     : null;
-  const posterUri = poster && domain ? `https://cdn.${domain}/images/${poster.filename}` : null;
-  const backgroundUri = background && domain ? `https://cdn.${domain}/images/${background.filename}` : null;
+  const backgroundUri = background && domain
+    ? `https://cdn.${domain}/images/${background.filename}`
+    : null;
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       {backgroundUri && <Image source={{ uri: backgroundUri }} style={styles.background} />}
-      {posterUri && <Image source={{ uri: posterUri }} style={styles.poster} />}
       <Text style={styles.title}>{info.name}</Text>
       {info.plot && <Text style={styles.plot}>{info.plot}</Text>}
       <Text style={styles.meta}>Durata: {info.duration ? `${info.duration} min` : 'N/A'}</Text>
@@ -58,12 +55,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   background: {
-    width: '100%',
-    height: 200,
-    borderRadius: 8,
-    marginBottom: 16,
-  },
-  poster: {
     width: '100%',
     height: 300,
     borderRadius: 8,

--- a/app/details/[completeSlug].jsx
+++ b/app/details/[completeSlug].jsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, Image, ScrollView } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+export default function Details() {
+  const { completeSlug, domain } = useLocalSearchParams();
+  const [info, setInfo] = useState(null);
+
+  useEffect(() => {
+    if (!completeSlug) return;
+
+    fetch(`https://strewebapp.riccardohs.it/api/get-extended-info/${completeSlug}`)
+      .then((res) => res.json())
+      .then(setInfo)
+      .catch(() => setInfo(null));
+  }, [completeSlug]);
+
+  if (!info) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.loading}>Caricamento...</Text>
+      </View>
+    );
+  }
+
+  const poster = Array.isArray(info.images)
+    ? info.images.find((img) => img.type === 'cover')
+    : null;
+  const posterUri = poster && domain ? `https://cdn.${domain}/images/${poster.filename}` : null;
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      {posterUri && <Image source={{ uri: posterUri }} style={styles.poster} />}
+      <Text style={styles.title}>{info.name}</Text>
+      {info.plot && <Text style={styles.plot}>{info.plot}</Text>}
+      <Text style={styles.meta}>Durata: {info.duration ? `${info.duration} min` : 'N/A'}</Text>
+      <Text style={styles.meta}>Valutazione: {info.rating ?? 'N/A'}</Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#212121',
+  },
+  content: {
+    padding: 20,
+  },
+  loading: {
+    color: 'white',
+    marginTop: 20,
+    textAlign: 'center',
+  },
+  poster: {
+    width: '100%',
+    height: 300,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  title: {
+    color: 'white',
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  plot: {
+    color: '#9ca3af',
+    marginBottom: 12,
+  },
+  meta: {
+    color: '#9ca3af',
+    marginBottom: 4,
+  },
+});

--- a/app/details/[completeSlug].jsx
+++ b/app/details/[completeSlug].jsx
@@ -1,10 +1,19 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, Image, ScrollView } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Image,
+  ScrollView,
+  TouchableOpacity,
+  Linking,
+} from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 
 export default function Details() {
   const { completeSlug, domain } = useLocalSearchParams();
   const [info, setInfo] = useState(null);
+  const [selectedSeason, setSelectedSeason] = useState(null);
 
   useEffect(() => {
     if (!completeSlug) return;
@@ -14,6 +23,15 @@ export default function Details() {
       .then(setInfo)
       .catch(() => setInfo(null));
   }, [completeSlug]);
+
+  useEffect(() => {
+    if (info?.episodeList?.length) {
+      const seasons = Array.from(
+        new Set(info.episodeList.map((e) => e.season))
+      ).sort((a, b) => a - b);
+      setSelectedSeason(seasons[0]);
+    }
+  }, [info]);
 
   if (!info) {
     return (
@@ -30,6 +48,15 @@ export default function Details() {
     ? `https://cdn.${domain}/images/${background.filename}`
     : null;
 
+  const seasons = info?.episodeList
+    ? Array.from(new Set(info.episodeList.map((e) => e.season))).sort(
+        (a, b) => a - b
+      )
+    : [];
+  const episodes = info?.episodeList
+    ? info.episodeList.filter((e) => e.season === selectedSeason)
+    : [];
+
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       {backgroundUri && <Image source={{ uri: backgroundUri }} style={styles.background} />}
@@ -37,6 +64,70 @@ export default function Details() {
       {info.plot && <Text style={styles.plot}>{info.plot}</Text>}
       <Text style={styles.meta}>Durata: {info.duration ? `${info.duration} min` : 'N/A'}</Text>
       <Text style={styles.meta}>Valutazione: {info.rating ?? 'N/A'}</Text>
+
+      {seasons.length > 0 && (
+        <>
+          <ScrollView
+            horizontal
+            style={styles.seasonSelector}
+            contentContainerStyle={styles.seasonList}
+            showsHorizontalScrollIndicator={false}
+          >
+            {seasons.map((s) => (
+              <TouchableOpacity
+                key={s}
+                onPress={() => setSelectedSeason(s)}
+                style={[
+                  styles.seasonButton,
+                  selectedSeason === s && styles.seasonButtonActive,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.seasonButtonText,
+                    selectedSeason === s && styles.seasonButtonTextActive,
+                  ]}
+                >
+                  Stagione {s}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+
+          <View style={styles.episodes}>
+            {episodes.map((ep) => {
+              const cover = Array.isArray(ep.images)
+                ? ep.images.find((img) => img.type === 'cover')
+                : null;
+              const coverUri = cover && domain
+                ? `https://cdn.${domain}/images/${cover.filename}`
+                : null;
+              const openEpisode = () => ep.url && Linking.openURL(ep.url);
+
+              return (
+                <TouchableOpacity
+                  key={ep.id}
+                  style={styles.episodeCard}
+                  onPress={openEpisode}
+                  disabled={!ep.url}
+                >
+                  {coverUri && (
+                    <Image source={{ uri: coverUri }} style={styles.episodeImage} />
+                  )}
+                  <View style={styles.episodeInfo}>
+                    <Text style={styles.episodeTitle}>
+                      {`${ep.episode}. ${ep.name}`}
+                    </Text>
+                    {ep.description && (
+                      <Text style={styles.episodeDesc}>{ep.description}</Text>
+                    )}
+                  </View>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </>
+      )}
     </ScrollView>
   );
 }
@@ -73,5 +164,53 @@ const styles = StyleSheet.create({
   meta: {
     color: '#9ca3af',
     marginBottom: 4,
+  },
+  seasonSelector: {
+    marginTop: 16,
+  },
+  seasonList: {
+    gap: 8,
+  },
+  seasonButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 20,
+    backgroundColor: '#2f2f2fff',
+  },
+  seasonButtonActive: {
+    backgroundColor: '#3f3f3f',
+  },
+  seasonButtonText: {
+    color: '#9ca3af',
+  },
+  seasonButtonTextActive: {
+    color: 'white',
+  },
+  episodes: {
+    marginTop: 16,
+    gap: 12,
+  },
+  episodeCard: {
+    flexDirection: 'row',
+    backgroundColor: '#2f2f2fff',
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  episodeImage: {
+    width: 120,
+    height: 80,
+  },
+  episodeInfo: {
+    flex: 1,
+    padding: 8,
+  },
+  episodeTitle: {
+    color: 'white',
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  episodeDesc: {
+    color: '#9ca3af',
+    fontSize: 12,
   },
 });

--- a/app/results.jsx
+++ b/app/results.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, FlatList, TouchableOpacity, Linking, Image } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity, Image } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 
 export default function Results() {
   const { query, domain } = useLocalSearchParams();
+  const router = useRouter();
   const [results, setResults] = useState([]);
 
   useEffect(() => {
@@ -20,14 +21,16 @@ export default function Results() {
 
           return {
             id: String(item.id),
+            slug: item.slug,
+            domain: imageDomain,
             title: item.name,
             type: item.type,
             score: item.score,
             lastAirDate: item.last_air_date,
-            poster: poster && imageDomain
-              ? `https://cdn.${imageDomain}/images/${poster.filename}`
-              : null,
-            url: item.url,
+            poster:
+              poster && imageDomain
+                ? `https://cdn.${imageDomain}/images/${poster.filename}`
+                : null,
           };
         });
         setResults(items);
@@ -35,15 +38,22 @@ export default function Results() {
       .catch(() => setResults([]));
   }, [query, domain]);
 
-  const renderItem = ({ item }) => (
-    <TouchableOpacity style={styles.card} onPress={() => Linking.openURL(item.url)}>
-      {item.poster && <Image source={{ uri: item.poster }} style={styles.poster} />}
-      <Text style={styles.cardTitle}>{item.title}</Text>
-      <Text style={styles.cardMeta}>Tipo: {item.type}</Text>
-      <Text style={styles.cardMeta}>Valutazione: {item.score ?? 'N/A'}</Text>
-      <Text style={styles.cardMeta}>Data di uscita: {item.lastAirDate ?? 'N/A'}</Text>
-    </TouchableOpacity>
-  );
+  const renderItem = ({ item }) => {
+    const completeSlug = `${item.id}-${item.slug}`;
+    const handlePress = () => {
+      router.push({ pathname: `/details/${completeSlug}`, params: { domain: item.domain } });
+    };
+
+    return (
+      <TouchableOpacity style={styles.card} onPress={handlePress}>
+        {item.poster && <Image source={{ uri: item.poster }} style={styles.poster} />}
+        <Text style={styles.cardTitle}>{item.title}</Text>
+        <Text style={styles.cardMeta}>Tipo: {item.type}</Text>
+        <Text style={styles.cardMeta}>Valutazione: {item.score ?? 'N/A'}</Text>
+        <Text style={styles.cardMeta}>Data di uscita: {item.lastAirDate ?? 'N/A'}</Text>
+      </TouchableOpacity>
+    );
+  };
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## Summary
- navigate to internal details screen when tapping a search result
- show extended info with poster, plot, duration and rating

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c68df20ec8333bfb5fae583bba421